### PR TITLE
Remove custom_settings

### DIFF
--- a/.github/workflows/update-algolia-index.yaml
+++ b/.github/workflows/update-algolia-index.yaml
@@ -1,7 +1,5 @@
 name: Update Algolia Index
 on:
-  # Temporarily triggering on pull requests to see if this actually works.
-  pull_request: {}
   # Allow manual triggers.
   workflow_dispatch: {}
   # Run once a day.

--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -16,11 +16,6 @@
       }
     }
   ],
-  "custom_settings": {
-    "attributesForFaceting": [
-      "version"
-    ]
-  },
   "stop_urls": [],
   "selectors": {
     "lvl0": ".section h1",


### PR DESCRIPTION
According to https://docsearch.algolia.com/docs/config-file/#using-regular-expressions
variables get added as attributes automatically. It's a shot in the
dark, but I'm trying to fix the issue where sometimes versions just
don't get added as attributes.

Signed-off-by: Michi Mutsuzaki <michi@isovalent.com>