### PR TITLE
Update selectors after docutils update

### DIFF
--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -17,12 +17,12 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".section h1",
-    "lvl1": ".section h2",
-    "lvl2": ".section h3",
-    "lvl3": ".section h4",
-    "lvl4": ".section h5",
-    "lvl5": ".section h6",
-    "text": ".section p, .section li, .section .code"
+    "lvl0": ".section h1, section h1",
+    "lvl1": ".section h2, section h2",
+    "lvl2": ".section h3, section h3",
+    "lvl3": ".section h4, section h4",
+    "lvl4": ".section h5, section h5",
+    "lvl5": ".section h6, section h6",
+    "text": ".section p, .section li, .section .code, section p, section li, section .code"
   }
 }


### PR DESCRIPTION
We recently updated the packages we use for building Cilium's documentation. Doing so, we switched to docutils v0.17, which introduces some subtle changes in the generated HTML. In particular, the `<div id="..." class="section">` nodes are replaced with `<section id="...">` ([commit](https://sourceforge.net/p/docutils/code/8472/)). One unexpected consequence of this change is that the indexing for the Algolia search now fails for the `latest` branch, which received the changes. This is because the selectors, in the JSON configuration file in this repository, rely on the class name `.section` and not on the `section` tag.

This commit update the selectors to use any of `.section` (class name) or `section` (tag), so that indexing can work with all branches. We can remove the `.section` in the future, when all supported branches rely on Docutils v0.17+ (when releasing Cilium v1.14?).
